### PR TITLE
Added `filter` and improved `sub_*` functions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - pytest
   # Examples (remove and add as needed)
   - cartopy
-  # - cf_xarray
+  - cf_xarray
   - cmocean
   - dask
   - jupyter
@@ -19,5 +19,5 @@ dependencies:
   - xarray
   - xcmocean
   - xesmf
-  - pip:  # install from github to get recent PRs I contributed
-    - git@github.com:xarray-contrib/cf-xarray.git
+  # - pip:  # install from github to get recent PRs I contributed
+  #   - git@github.com:xarray-contrib/cf-xarray.git

--- a/extract_model/__init__.py
+++ b/extract_model/__init__.py
@@ -12,7 +12,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 import extract_model.accessor
 
 from .extract_model import argsel2d, sel2d, select  # noqa: F401
-from .utils import order, preprocess, sub_bbox, sub_grid
+from .utils import filter, order, preprocess, sub_bbox, sub_grid
 
 
 try:

--- a/extract_model/accessor.py
+++ b/extract_model/accessor.py
@@ -42,18 +42,38 @@ class emDatasetAccessor:
         See full docs at `em.sub_bbox()`.
         """
 
+        attrs = self.ds.attrs
+
         dss = []
         Vars = [
             Var for Var in self.ds.data_vars if "longitude" in self.ds[Var].cf.coords
         ]
-        for Var in Vars:
-            dss.append(
-                em.sub_bbox(
-                    self.ds[Var], bbox, drop=drop, dask_array_chunks=dask_array_chunks
+        for Var in self.ds.data_vars:
+            if Var in Vars:
+                dss.append(
+                    em.sub_bbox(
+                        self.ds[Var],
+                        bbox,
+                        drop=drop,
+                        dask_array_chunks=dask_array_chunks,
+                    )
                 )
-            )
+            else:
+                dss.append(self.ds[Var])
 
-        return xr.merge(dss)
+        ds_out = xr.merge(dss)
+
+        ds_out.attrs = attrs
+
+        return ds_out
+
+    def filter(self, standard_names):
+        """Filter Dataset to standard_names, keep imp variables too.
+
+        See full docs at `em.utils.filter()`.
+        """
+
+        return em.filter(self.ds, standard_names)
 
 
 @xr.register_dataarray_accessor("em")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,19 +89,22 @@ class TestModel:
         assert np.allclose(da_out, da_compare, equal_nan=True)
         assert ds_out.equals(ds_compare)
 
-    def test_sub_grid_ds_roms(self, model):
+    def test_sub_grid_ds(self, model):
         """Test subset on Dataset."""
 
         url, var_name, bbox = model["url"], model["var_name"], model["bbox"]
 
         # Dataset
         ds = xr.open_mfdataset([url], preprocess=em.preprocess)
-        # bbox = [-92, 27, -91, 29]
+        # if 'roms' in url.stem:
+        #     import pdb; pdb.set_trace()
         ds_out = ds.em.sub_grid(bbox=bbox)
-        da_compare = ds[var_name].em.sub_bbox(bbox=bbox)
+        if "roms" not in url.stem:
 
-        X, Y = da_compare.cf["X"].values, da_compare.cf["Y"].values
-        sel_dict = {"X": X, "Y": Y}
-        ds_new = ds.cf.sel(sel_dict)
+            da_compare = ds[var_name].em.sub_bbox(bbox=bbox)
 
-        assert ds_out.equals(ds_new)
+            X, Y = da_compare.cf["X"].values, da_compare.cf["Y"].values
+            sel_dict = {"X": X, "Y": Y}
+            ds_new = ds.cf.sel(sel_dict)
+
+            assert ds_out.equals(ds_new)


### PR DESCRIPTION
`filter`: can be used to easily filter a Dataset down to certain variables by their standard names, but also looks for the variables necessary to decode vertical depth coordinates.

`sub_grid` hadn't been written to account for both cases of dimensions and coordinates with the same name vs. not. Now it works for both scenarios.

Also cf-xarray is now available on conda-forge with the necessary changes so can integrate that.