### PR TITLE
Adds support for POM coordinates

### DIFF
--- a/extract_model/utils.py
+++ b/extract_model/utils.py
@@ -448,12 +448,30 @@ def preprocess_pom(ds):
 
     Parameters
     ----------
-    ds: xarray Dataset
+    ds : xr.Dataset
+        A dataset containing data described from POM output.
 
     Returns
     -------
-    Same Dataset but with some metadata added and/or altered.
+    xr.Dataset
+        Same Dataset but with some metadata added and/or altered.
     """
+    # The longitude and latitude variables are not recognized as valid coordinates
+    if "longitude" not in ds.cf.coords:
+        if "longitude" not in ds.cf.standard_names:
+            raise ValueError("No variable describing longitude is available.")
+        lon_varname = ds.cf.standard_names["longitude"][0]
+
+        if "latitude" not in ds.cf.standard_names:
+            raise ValueError("No variable describing latitude is available.")
+        lat_varname = ds.cf.standard_names["latitude"][0]
+
+        ds = ds.assign_coords(
+            {
+                lon_varname: ds[lon_varname],
+                lat_varname: ds[lat_varname],
+            }
+        )
 
     # need to also make this a coordinate to add attributes
     ds["nx"] = ("nx", np.arange(ds.sizes["nx"]), {"axis": "X"})

--- a/extract_model/utils.py
+++ b/extract_model/utils.py
@@ -460,11 +460,9 @@ def preprocess_pom(ds):
     if "longitude" not in ds.cf.coords:
         if "longitude" not in ds.cf.standard_names:
             raise ValueError("No variable describing longitude is available.")
-        lon_varname = ds.cf.standard_names["longitude"][0]
 
         if "latitude" not in ds.cf.standard_names:
             raise ValueError("No variable describing latitude is available.")
-        lat_varname = ds.cf.standard_names["latitude"][0]
 
         ds = ds.cf.set_coords(["latitude", "longitude"])
 

--- a/extract_model/utils.py
+++ b/extract_model/utils.py
@@ -466,12 +466,7 @@ def preprocess_pom(ds):
             raise ValueError("No variable describing latitude is available.")
         lat_varname = ds.cf.standard_names["latitude"][0]
 
-        ds = ds.assign_coords(
-            {
-                lon_varname: ds[lon_varname],
-                lat_varname: ds[lat_varname],
-            }
-        )
+        ds = ds.cf.set_coords(["latitude", "longitude"])
 
     # need to also make this a coordinate to add attributes
     ds["nx"] = ("nx", np.arange(ds.sizes["nx"]), {"axis": "X"})


### PR DESCRIPTION
The default metadata avilable from model output from POM lacks
coordinate attributes which are needed by xarray and cf-xarray to
determine the grid coordinate mappings. This commit explicitly handles
hte case for POM by assigning the lon and lat variables as coordinates
to the xr.Dataset for POM data.