### PR TITLE
FVCOM `sub_grid` support

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -11,3 +11,4 @@ v0.7.0 (July 22, 2022)
   datasets, even if the data do not specify `coordinates` attributes explicitly.
 * `em.sub_bbox()` supports subsetting FVCOM model output.
 * A new jupyter notebook demonstrating subsetting of FVCOM model output is now available in docs.
+* `em.sub_grid()` supports subsetting FVCOM model output.

--- a/extract_model/accessor.py
+++ b/extract_model/accessor.py
@@ -32,15 +32,14 @@ class emDatasetAccessor:
         # extra for getting coordinates but changes variables
         self._ds = ds.copy(deep=True)
 
-    def sub_grid(self, bbox, drop=True):
+    def sub_grid(self, bbox, drop=True, **kwargs):
         """Subset Dataset in space defined by bbox.
 
         Returns full set of grids that preserve structure.
 
         See full docs at `em.sub_grid()`.
         """
-
-        return em.sub_grid(self.ds, bbox)
+        return em.sub_grid(self.ds, bbox, **kwargs)
 
     def sub_bbox(
         self,

--- a/tests/grids/test_triangular_mesh.py
+++ b/tests/grids/test_triangular_mesh.py
@@ -107,3 +107,37 @@ def test_subset_accessor(real_fvcom):
     assert ds is not None
     assert ds.dims["node"] == 1833
     assert ds.dims["nele"] == 3392
+
+
+def test_sub_grid_accessor(real_fvcom):
+    bbox = (276.4, 41.5, 277.4, 42.1)
+    ds = real_fvcom.em.sub_grid(bbox=bbox)
+    assert ds is not None
+    assert ds.dims["node"] == 1833
+    assert ds.dims["nele"] == 3392
+    # Check a node variable
+    np.testing.assert_allclose(
+        ds["x"][:10],
+        np.array(
+            [
+                543232.0,
+                544512.0,
+                546048.0,
+                547584.0,
+                549056.0,
+                544512.0,
+                543232.0,
+                545920.0,
+                547584.0,
+                549056.0,
+            ],
+            dtype=np.float32,
+        ),
+    )
+
+    np.testing.assert_array_equal(ds["nv"][:, 0], np.array([6, 7, 1], dtype=np.int32))
+
+    ds = real_fvcom.em.sub_grid(bbox=bbox, model_type="FVCOM")
+    assert ds is not None
+    assert ds.dims["node"] == 1833
+    assert ds.dims["nele"] == 3392

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,8 @@ import xarray as xr
 
 import extract_model as em
 
+from extract_model.utils import sub_grid
+
 from .utils import read_model_configs
 
 
@@ -148,3 +150,16 @@ def test_sub_grid_ds(model):
         ds_new = ds.cf.sel(sel_dict)
 
         assert ds_out.equals(ds_new)
+
+
+def test_sub_grid_assert():
+    """Ensures that sub_grid will raise if passed an xr.DataArray."""
+    xvar = xr.DataArray(data=np.arange(20), dims=("time",))
+    bbox = (
+        0.0,
+        0.0,
+        1.0,
+        1.0,
+    )
+    with pytest.raises(ValueError):
+        sub_grid(ds=xvar, bbox=bbox)


### PR DESCRIPTION
Adds FVCOM subsetting to sub_grid

sub_bbox and sub_grid behave similarly, and since FVCOM subsetting
retains the grid "structure" after subsetting, the same behavior will
suffice for both sub_bbox and sub_grid. This commit updates sub_grid
accessor to enable subsetting FVCOM data.


## Pull Request Reminders
- [ ] Make sure the docs notebooks `models.ipynb` and `ts_work.ipynb` still run.
- [x] Add tests for the new functionality.
- [x] Add a bullet to `docs/whats_new.rst` describing your new work.
