### PR TITLE
FVCOM Support for the `filtering` method.

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -12,3 +12,5 @@ v0.7.0 (July 22, 2022)
 * `em.sub_bbox()` supports subsetting FVCOM model output.
 * A new jupyter notebook demonstrating subsetting of FVCOM model output is now available in docs.
 * `em.sub_grid()` supports subsetting FVCOM model output.
+* `em.filter()` will not discard any unstructured coordinate information in the auxiliary coordinate
+  variables.

--- a/extract_model/grids/triangular_mesh.py
+++ b/extract_model/grids/triangular_mesh.py
@@ -67,6 +67,15 @@ def index_of_sorted(
 class UnstructuredGridSubset:
     """A class for subsetting unstructured grids."""
 
+    FVCOM_COORDINATE_VARIABLES = [
+        "nv",
+        "nbe",
+        "ntsn",
+        "nbsn",
+        "ntve",
+        "nbve",
+    ]
+
     def __init__(self):
         """Initializes the subsetting class."""
         pass

--- a/extract_model/utils.py
+++ b/extract_model/utils.py
@@ -18,6 +18,7 @@ def filter(
     keep_horizontal_coords: bool = True,
     keep_vertical_coords: bool = True,
     keep_coord_mask: bool = True,
+    model_type: Optional[ModelType] = None,
 ):
     """Filter Dataset by variables
 
@@ -46,6 +47,13 @@ def filter(
         formula_terms needed to decode vertical coordinates using `cf-xarray`.
     """
     to_merge = []
+    if model_type is not None and not isinstance(model_type, ModelType):
+        model_type = ModelType(model_type)
+
+    model_type_guess = model_type or guess_model_type(ds)
+
+    if model_type_guess == "FVCOM":
+        to_merge.append(ds[UnstructuredGridSubset.FVCOM_COORDINATE_VARIABLES])
 
     if keep_vertical_coords:
         # Deal with vertical coord decoding

--- a/tests/grids/test_triangular_mesh.py
+++ b/tests/grids/test_triangular_mesh.py
@@ -141,3 +141,12 @@ def test_sub_grid_accessor(real_fvcom):
     assert ds is not None
     assert ds.dims["node"] == 1833
     assert ds.dims["nele"] == 3392
+
+
+def test_filter(real_fvcom):
+
+    standard_names = ["sea_water_temperature"]
+    ds_filtered = real_fvcom.em.filter(standard_names=standard_names)
+    varnames = sorted(ds_filtered.variables)
+    for coord_var in UnstructuredGridSubset.FVCOM_COORDINATE_VARIABLES:
+        assert coord_var in varnames


### PR DESCRIPTION
Adds filtering support for FVCOM

FVCOM has several auxiliary coordinate variables that are required to be
kept within the dataset in order for grid accessible to feasible. These
are not-optionally kept, they must be kept with the data. This commit
extends the filter method to keep these required auxiliary coordinate
variables.

## Pull Request Reminders
- [ ] Make sure the docs notebooks `models.ipynb` and `ts_work.ipynb` still run.
- [x] Add tests for the new functionality.
- [x] Add a bullet to `docs/whats_new.rst` describing your new work.
