### PR TITLE
Fix for test_grid_point_isel_Z non-determinism

### DIFF
--- a/tests/test_em.py
+++ b/tests/test_em.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+
+import warnings
+
 from pathlib import Path
 from time import time
 
@@ -139,7 +144,11 @@ def test_grid_point_isel_Z(model):
         tb1 = time() - tb0
 
         # using weights should be faster than not
-        assert ta1 > tb1
+        if ta1 <= tb1:
+            warnings.warn(
+                "2D interpolation time did not improve after computing weights, weights may not have been used.",
+                RuntimeWarning,
+            )
 
     # this should only run if xESMF is installed
     except ModuleNotFoundError:  # pragma: no cover


### PR DESCRIPTION
This commit changes an assertion into a warning. The test initially made
an assertion about the timing taken, but on CI testing environments this
timing can't necessarily be reliable due to resource sharing and other
modern contention issues with CIs, so instead we simply issue a warning
that it was slower than expected.

## Pull Request Reminders
- [x] Make sure the notebooks in the `docs` directory all run.
- [x] Add tests for the new functionality.
- [x] Add a bullet to `docs/whats_new.rst` describing your new work. If not already present, add a new section at the top of the document stating "[expected new version number] (unreleased)", for example: "v0.7.3 (unreleased)"
