### PR TITLE
Adds option to preload data for unstructured subsetting

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1,14 +1,20 @@
 :mod:`What's New`
 ----------------------------
 
+v0.9.0 (Release Candidate)
+==========================
+* An optional subsetting option that enables subsetting directly on the target
+  dataset's dimensions. For remote datasets, this ensures that remote requests
+  ask for minimal slices. `em.sub_grid(..., naive=True)`.
+* Adds `preload` argument for unstructured grid subsetting. Radically improves xarray resolution
+  times after subsetting.
+
 v0.8.1 (August 16, 2022)
 ===================
 
 * Support for SELFE datasets is now incorporated into `em.sub_grid()` `em.sub_bbox()` and
   `em.filter()`.
 * Support for numba and numpy implementations of `index_of_sorted()`.
-* Adds `preload` argument for unstructured grid subsetting. Radically improves xarray resolution
-  times after subsetting.
 
 v0.8.0 (August 3, 2022)
 =======================

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -7,6 +7,8 @@ v0.8.1 (August 16, 2022)
 * Support for SELFE datasets is now incorporated into `em.sub_grid()` `em.sub_bbox()` and
   `em.filter()`.
 * Support for numba and numpy implementations of `index_of_sorted()`.
+* Adds `preload` argument for unstructured grid subsetting. Radically improves xarray resolution
+  times after subsetting.
 
 v0.8.0 (August 3, 2022)
 =======================

--- a/extract_model/utils.py
+++ b/extract_model/utils.py
@@ -62,8 +62,8 @@ def filter(
     elif model_type_guess == "SELFE":
         to_merge.append(ds[UnstructuredGridSubset.SELFE_COORDINATE_VARIABLES])
 
-    if 'angle' in ds.variables:
-        to_merge.append(ds['angle'])
+    if "angle" in ds.variables:
+        to_merge.append(ds["angle"])
 
     if keep_vertical_coords:
         # Deal with vertical coord decoding

--- a/extract_model/utils.py
+++ b/extract_model/utils.py
@@ -3,13 +3,18 @@
 """
 Utilities to help extract_model work better.
 """
-from typing import List, Optional
+from itertools import product
+from typing import List, Mapping, NewType, Optional, Tuple
 
+import dask
 import numpy as np
 import xarray as xr
 
 from extract_model.grids.triangular_mesh import UnstructuredGridSubset
 from extract_model.model_type import ModelType
+
+
+BBoxType = NewType("BBoxType", Tuple[float, float, float, float])
 
 
 def filter(
@@ -133,7 +138,141 @@ def filter(
     return xr.merge(to_merge)
 
 
-def sub_grid(ds, bbox, dask_array_chunks=True, model_type: Optional[ModelType] = None):
+def naive_subbox(ds: xr.Dataset, bbox: BBoxType, dask_array_chunks: bool = False):
+    """Perform subsetting directly using dimension slicing.
+
+    naive_subbox performs subsetting by means of directly slicing along the grid
+    dimensions in lieu of using a mask combined with da.where. Slicing along the
+    dimensions directly is useful when access data remotely where bandwidth is a
+    significant concern. This approach ensures that requests for data will
+    request the minimal set of data possible.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The gridded data to subset.
+    bbox : BBoxType (tuple)
+        The desired codomain.
+    dask_array_chunks : bool
+        Set to True to use dask array chunking for large grids that don't fit
+        into memory.
+    """
+    model_type = guess_model_type(ds)
+    lons = ds.cf[["longitude"]]
+    lon_coords = sorted(set(lons.coords) - set(lons.dims))
+
+    lats = ds.cf[["latitude"]]
+    lat_coords = sorted(set(lats.coords) - set(lats.dims))
+
+    lon_is_coordinate_variable = False
+    lat_is_coordinate_variable = False
+    # Check if lon is a coordinate variable
+    if len(ds.cf.standard_names["longitude"]) == 1:
+        varname = ds.cf.standard_names["longitude"][0]
+        if ds[varname].dims == (varname,):
+            lon_is_coordinate_variable = True
+    if len(ds.cf.standard_names["latitude"]) == 1:
+        varname = ds.cf.standard_names["latitude"][0]
+        if ds[varname].dims == (varname,):
+            lat_is_coordinate_variable = True
+
+    if lon_is_coordinate_variable != lat_is_coordinate_variable:
+        raise ValueError("Invalid grid detected")
+
+    if lon_is_coordinate_variable:
+        lon_data = ds.cf["longitude"][:]
+        lat_data = ds.cf["latitude"][:]
+        lon_mask = np.where((lon_data >= bbox[0]) & (lon_data <= bbox[2]))[0]
+        lat_mask = np.where((lat_data >= bbox[1]) & (lat_data <= bbox[3]))[0]
+        x0 = np.min(lon_mask)
+        x1 = np.max(lon_mask)
+        y0 = np.min(lat_mask)
+        y1 = np.max(lat_mask)
+        with dask.config.set(**{"array.slicing.split_large_chunks": dask_array_chunks}):
+            return ds.cf.isel(longitude=slice(x0, x1), latitude=slice(y0, y1))
+
+    grid_mappings = []
+
+    for lon_coord in lon_coords:
+        for lat_coord in lat_coords:
+            if ds[lon_coord].dims == ds[lat_coord].dims:
+                grid_mappings.append(
+                    {"lon": lon_coord, "lat": lat_coord, "dims": ds[lon_coord].dims}
+                )
+                break
+    slices = {}
+
+    # Staggered grid case for ROMS
+    roms_native_coords = ["eta", "xi"]
+    roms_cell_coords = ["rho", "u", "v", "psi"]
+    roms_coords = [
+        f"{native}_{cell}"
+        for cell, native in product(roms_cell_coords, roms_native_coords)
+    ]
+    if (
+        model_type == "ROMS"
+        and all([i in ds.coords for i in ["lon_rho", "lat_rho"]])
+        and all([coord in ds.dims for coord in roms_coords])
+    ):
+        slices = _slice_grid_mapping(
+            ds, "lon_rho", "lat_rho", ["eta_rho", "xi_rho"], bbox
+        )
+        eta_rho: slice = slices["eta_rho"]
+        xi_rho: slice = slices["xi_rho"]
+        slices["eta_u"] = eta_rho
+        slices["xi_u"] = slice(xi_rho.start, xi_rho.stop - 1)
+
+        slices["eta_v"] = slice(eta_rho.start, eta_rho.stop - 1)
+        slices["xi_v"] = xi_rho
+
+        slices["eta_psi"] = slice(eta_rho.start, eta_rho.stop - 1)
+        slices["xi_psi"] = slice(xi_rho.start, xi_rho.stop - 1)
+
+        with dask.config.set(**{"array.slicing.split_large_chunks": dask_array_chunks}):
+            return ds.isel(**slices)
+
+    for grid_mapping in grid_mappings:
+        lon = grid_mapping["lon"]
+        lat = grid_mapping["lat"]
+        dims = grid_mapping["dims"]
+        grid_slices = _slice_grid_mapping(ds, lon, lat, dims, bbox)
+        slices.update(grid_slices)
+
+    with dask.config.set(**{"array.slicing.split_large_chunks": dask_array_chunks}):
+        return ds.isel(**slices)
+
+
+def _slice_grid_mapping(
+    ds: xr.Dataset, lon: str, lat: str, dims: List[str], bbox: BBoxType
+) -> Mapping[str, slice]:
+    slices = {}
+    lon_data = ds[lon][:].to_numpy()
+    lat_data = ds[lat][:].to_numpy()
+
+    mask = (
+        (lon_data >= bbox[0])
+        & (lon_data <= bbox[2])
+        & (lat_data >= bbox[1])
+        & (lat_data <= bbox[3])
+    )
+    if not np.any(mask):
+        raise ValueError("Bounding box does not intersect dataset domain")
+    mask_i = np.where(mask)
+    x0, y0 = np.min(mask_i[0]), np.min(mask_i[1])
+    x1, y1 = np.max(mask_i[0]) + 1, np.max(mask_i[1]) + 1
+    slices[dims[0]] = slice(x0, x1)
+    slices[dims[1]] = slice(y0, y1)
+    return slices
+
+
+def sub_grid(
+    ds: xr.Dataset,
+    bbox: BBoxType,
+    dask_array_chunks=True,
+    model_type: Optional[ModelType] = None,
+    naive: bool = False,
+    preload: bool = False,
+):
     """Subset Dataset grids.
 
     Preserves horizontal grid structure, which matters for ROMS.
@@ -157,6 +296,12 @@ def sub_grid(ds, bbox, dask_array_chunks=True, model_type: Optional[ModelType] =
     model_type : ModelType, optional
         Clients may explicitly specify the model type for the grid and data in `ds`. If this
         parameter isn't specified, it is guessed based on the metadata available.
+    naive : bool
+        Causes the subetting method to use naive_subset which has better performance over DAP.
+    preload : bool
+        If the subsetting algorithm supports it, the data will be preloaded
+        before reindexed (only applicable to unstructured grids). Defaults to
+        False.
 
     Returns
     -------
@@ -174,10 +319,13 @@ def sub_grid(ds, bbox, dask_array_chunks=True, model_type: Optional[ModelType] =
     model_type_guess = model_type or guess_model_type(ds)
     if model_type_guess == "FVCOM":
         subsetter = UnstructuredGridSubset()
-        return subsetter.subset(ds=ds, bbox=bbox, grid_type="fvcom")
+        return subsetter.subset(ds=ds, bbox=bbox, grid_type="fvcom", preload=preload)
     if model_type_guess == "SELFE":
         subsetter = UnstructuredGridSubset()
-        return subsetter.subset(ds=ds, bbox=bbox, grid_type="selfe")
+        return subsetter.subset(ds=ds, bbox=bbox, grid_type="selfe", preload=preload)
+
+    if naive:
+        return naive_subbox(ds=ds, bbox=bbox, dask_array_chunks=dask_array_chunks)
 
     attrs = ds.attrs
 
@@ -203,7 +351,6 @@ def sub_grid(ds, bbox, dask_array_chunks=True, model_type: Optional[ModelType] =
             # index
             i_xi_rho = int((subs != -500).sum(dim="xi_rho").argmax())
             xi_rho_bool = subs.isel(eta_rho=i_xi_rho) != -500
-            # import pdb; pdb.set_trace()
             if "T" in subs.cf.axes:
                 xi_rho_bool = xi_rho_bool.cf.isel(T=0)
             if "Z" in subs.cf.axes:
@@ -588,7 +735,14 @@ def preprocess(ds, model_type=None):
 
 def guess_model_type(ds: xr.Dataset) -> Optional[ModelType]:
     """Returns a guess as to which model produced the dataset."""
+    selfe_dims = ["nele", "node"]
     for model_type in ModelType:
         if model_type in "".join([str(val) for val in ds.attrs.values()]):
+            if model_type == "FVCOM" and not all(
+                ["nv" in ds.variables, "node" in ds.dims]
+            ):
+                return None
+            if model_type == "SELFE" and not all([i in ds.dims for i in selfe_dims]):
+                return None
             return ModelType(model_type)
     return None

--- a/extract_model/utils.py
+++ b/extract_model/utils.py
@@ -62,6 +62,9 @@ def filter(
     elif model_type_guess == "SELFE":
         to_merge.append(ds[UnstructuredGridSubset.SELFE_COORDINATE_VARIABLES])
 
+    if 'angle' in ds.variables:
+        to_merge.append(ds['angle'])
+
     if keep_vertical_coords:
         # Deal with vertical coord decoding
 

--- a/tests/grids/test_triangular_mesh.py
+++ b/tests/grids/test_triangular_mesh.py
@@ -320,3 +320,11 @@ def test_unsupported_grid(selfe_data):
         subsetter.subset(None, (0, 0, 1, 1), "unreal")
     with pytest.raises(ValueError):
         subsetter.get_intersecting_mask(None, (0, 0, 1, 1), "unreal")
+
+
+def test_non_intersecting_subset(real_fvcom, selfe_data):
+    bbox = (0, 0, 10, 10)
+    with pytest.raises(ValueError):
+        real_fvcom.em.sub_grid(bbox=bbox)
+    with pytest.raises(ValueError):
+        selfe_data.em.sub_grid(bbox=bbox)

--- a/tests/grids/test_triangular_mesh.py
+++ b/tests/grids/test_triangular_mesh.py
@@ -59,10 +59,11 @@ def test_triangle_algorithms(fake_fvcom):
     )
 
 
-def test_fvcom_subset(real_fvcom):
+@pytest.mark.parametrize("preload", [False, True], ids=lambda x: f"preload={x}")
+def test_fvcom_subset(real_fvcom, preload):
     bbox = (276.4, 41.5, 277.4, 42.1)
     subsetter = UnstructuredGridSubset()
-    ds = subsetter.subset(real_fvcom, bbox, "fvcom")
+    ds = subsetter.subset(real_fvcom, bbox, "fvcom", preload=preload)
     assert ds is not None
     assert ds.dims["node"] == 1833
     assert ds.dims["nele"] == 3392
@@ -87,6 +88,7 @@ def test_fvcom_subset(real_fvcom):
     )
 
     np.testing.assert_array_equal(ds["nv"][:, 0], np.array([6, 7, 1], dtype=np.int32))
+    assert not np.any(ds["nv"][:] < 1)
 
 
 def test_fvcom_subset_accessor(real_fvcom):
@@ -123,9 +125,10 @@ def test_fvcom_subset_accessor(real_fvcom):
     assert ds.dims["nele"] == 3392
 
 
-def test_fvcom_sub_grid_accessor(real_fvcom):
+@pytest.mark.parametrize("preload", [False, True], ids=lambda x: f"preload={x}")
+def test_fvcom_sub_grid_accessor(real_fvcom, preload):
     bbox = (276.4, 41.5, 277.4, 42.1)
-    ds = real_fvcom.em.sub_grid(bbox=bbox)
+    ds = real_fvcom.em.sub_grid(bbox=bbox, preload=preload)
     assert ds is not None
     assert ds.dims["node"] == 1833
     assert ds.dims["nele"] == 3392
@@ -151,7 +154,7 @@ def test_fvcom_sub_grid_accessor(real_fvcom):
 
     np.testing.assert_array_equal(ds["nv"][:, 0], np.array([6, 7, 1], dtype=np.int32))
 
-    ds = real_fvcom.em.sub_grid(bbox=bbox, model_type="FVCOM")
+    ds = real_fvcom.em.sub_grid(bbox=bbox, model_type="FVCOM", preload=preload)
     assert ds is not None
     assert ds.dims["node"] == 1833
     assert ds.dims["nele"] == 3392
@@ -186,16 +189,36 @@ def test_fvcom_filter(real_fvcom):
         assert coord_var in varnames
 
 
-def test_fvcom_subset_scalars(real_fvcom):
+@pytest.mark.parametrize("preload", [False, True], ids=lambda x: f"preload={x}")
+def test_fvcom_subset_scalars(real_fvcom, preload):
     bbox = (276.4, 41.5, 277.4, 42.1)
     xvar = xr.DataArray(data=np.array(0.0), attrs={"long_name": "Example Data"})
     ds = real_fvcom.assign(variables={"example": xvar})
-    ds_ss = ds.em.sub_grid(bbox=bbox)
+    ds_ss = ds.em.sub_grid(bbox=bbox, preload=preload)
     assert ds_ss is not None
     assert ds_ss.dims["node"] == 1833
     assert ds_ss.dims["nele"] == 3392
     assert "example" in ds_ss.variables
     assert len(ds_ss["example"].dims) < 1
+
+
+@pytest.mark.parametrize("preload", [False, True], ids=lambda x: f"preload={x}")
+def test_fvcom_nv_reindexing(real_fvcom, preload):
+    bbox = (280, 42.2, 281, 43)
+    ds_ss = real_fvcom.em.sub_grid(bbox=bbox, preload=preload)
+    expected = np.array([[1, 11, 11], [10, 10, 1], [9, 1, 2]])
+    np.testing.assert_equal(expected, ds_ss["nv"].to_numpy()[:, :3])
+
+
+def test_fvcom_preload(real_fvcom):
+    """Test preloading vs normal reindexing."""
+    bbox = (280, 42.2, 281, 43)
+    ds_ss_norm = real_fvcom.em.sub_grid(bbox=bbox, preload=False)
+    ds_ss_preload = real_fvcom.em.sub_grid(bbox=bbox, preload=True)
+    for variable in sorted(ds_ss_norm.variables):
+        raw_data_norm = ds_ss_norm[variable].to_numpy()
+        raw_data_preload = ds_ss_preload[variable].to_numpy()
+        np.testing.assert_equal(raw_data_norm, raw_data_preload)
 
 
 def test_fvcom_preprocess(real_fvcom):
@@ -229,9 +252,10 @@ def test_selfe_sub_bbox_accessor(selfe_data):
     )
 
 
-def test_selfe_sub_grid_accessor(selfe_data):
+@pytest.mark.parametrize("preload", [False, True], ids=lambda x: f"preload={x}")
+def test_selfe_sub_grid_accessor(selfe_data, preload):
     bbox = (-123.8, 46.2, -123.6, 46.3)
-    ds_ss = selfe_data.em.sub_grid(bbox=bbox)
+    ds_ss = selfe_data.em.sub_grid(bbox=bbox, preload=preload)
     assert ds_ss is not None
     assert ds_ss.dims["node"] == 4273
     assert ds_ss.dims["nele"] == 8178
@@ -255,16 +279,28 @@ def test_selfe_sub_grid_accessor(selfe_data):
     )
 
 
-def test_selfe_subset_scalars(selfe_data):
+@pytest.mark.parametrize("preload", [False, True], ids=lambda x: f"preload={x}")
+def test_selfe_subset_scalars(selfe_data, preload):
     xvar = xr.DataArray(data=np.array(0.0), attrs={"long_name": "Example Data"})
     ds = selfe_data.assign(variables={"example": xvar})
     bbox = (-123.8, 46.2, -123.6, 46.3)
-    ds_ss = ds.em.sub_grid(bbox=bbox)
+    ds_ss = ds.em.sub_grid(bbox=bbox, preload=preload)
     assert ds_ss is not None
     assert ds_ss.dims["node"] == 4273
     assert ds_ss.dims["nele"] == 8178
     assert "example" in ds_ss.variables
     assert len(ds_ss["example"].dims) < 1
+
+
+def test_selfe_preload(selfe_data: xr.Dataset):
+    """Test preloading vs normal reindexing."""
+    bbox = (-123.8, 46.2, -123.6, 46.3)
+    ds_ss_norm = selfe_data.em.sub_grid(bbox=bbox, preload=False)
+    ds_ss_preload = selfe_data.em.sub_grid(bbox=bbox, preload=True)
+    for variable in sorted(ds_ss_norm.variables):
+        raw_data_norm = ds_ss_norm[variable].to_numpy()
+        raw_data_preload = ds_ss_preload[variable].to_numpy()
+        np.testing.assert_equal(raw_data_norm, raw_data_preload)
 
 
 def test_selfe_filter(selfe_data):

--- a/tests/model_configs.yaml
+++ b/tests/model_configs.yaml
@@ -33,6 +33,10 @@ HYCOM_01:
   lonslice: slice(10, 15)
   latslice: slice(10, 15)
   model_names: [None, "eastward_sea_water_velocity", None, None, None]
+  naive_subbox:
+    depth: 5
+    lat: 50
+    lon: 25
 
 HYCOM_02:
   url: Path(__file__).parent / "data/test_hycom2.nc"
@@ -51,6 +55,10 @@ HYCOM_02:
   lonslice: slice(10, 15)
   latslice: slice(10, 15)
   model_names: [None, "eastward_sea_water_velocity", None, None, None]
+  naive_subbox:
+    Depth: 2
+    Latitude: 113
+    Longitude: 60
 
 ROMS:
   url: Path(__file__).parent / "data/test_roms.nc"
@@ -69,3 +77,7 @@ ROMS:
   lonslice: slice(10, 15)
   latslice: slice(10, 15)
   model_names: ["sea_surface_elevation", None, None, None, None]
+  naive_subbox:
+    eta_rho: 100
+    xi_rho: 74
+    ocean_time: 2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -180,3 +180,24 @@ def test_sub_grid_assert():
     )
     with pytest.raises(ValueError):
         sub_grid(ds=xvar, bbox=bbox)
+
+
+def test_naive_subbox_illegal_grid():
+    """Ensure that we raise when the grid is invalid.
+    
+    An invalid grid can sometimes arise from someone mislabling a variable as a
+    coordinate or other copypasta errors.
+    """
+    eta = np.arange(100)
+    xi = np.arange(100)
+    lon = np.linspace(-30, 40, 100)
+    _, lat = np.meshgrid(lon, np.linspace(-20, 20, 100))
+    data_dict = {}
+    data_dict['eta'] = xr.DataArray(eta, dims=('eta',))
+    data_dict['xi'] = xr.DataArray(xi, dims=('xi',))
+    data_dict['lon'] = xr.DataArray(lon, dims=('lon',), attrs={'standard_name': 'longitude', 'units': 'degrees_east'})
+    data_dict['lat'] = xr.DataArray(lat, dims=('eta', 'xi'), attrs={'standard_name': 'latitude', 'units': 'degrees_north'})
+    ds = xr.Dataset(data_dict)
+    with pytest.raises(ValueError) as err:
+        em.utils.naive_subbox(ds=ds, bbox=(0, 0, 5, 5))
+        assert str(err) == 'Invalid grid detected'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -130,6 +130,23 @@ def test_sub_bbox(model):
 
 
 @pytest.mark.parametrize("model", models, ids=lambda x: x["name"])
+def test_naive_sub_bbox(model):
+    if model["name"] == "MOM6":
+        # MOM6 doesn't provide a CF-compliant grid description, clients
+        # shouldn't use naive_subbox for MOM6.
+        pytest.skip("MOM6 is not supported by naive_subbox")
+        return
+    var_name, bbox = model["var"], model["sub_bbox"]
+    pth = eval(model["url"])
+
+    # Dataset
+    ds = xr.open_mfdataset([pth], preprocess=em.preprocess)
+    ds_out = ds.em.sub_grid(bbox=bbox, naive=True)
+    for dim, value in model["naive_subbox"].items():
+        assert ds_out.dims[dim] == value
+
+
+@pytest.mark.parametrize("model", models, ids=lambda x: x["name"])
 def test_sub_grid_ds(model):
     """Test subset on Dataset."""
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -201,3 +201,17 @@ def test_naive_subbox_illegal_grid():
     with pytest.raises(ValueError) as err:
         em.utils.naive_subbox(ds=ds, bbox=(0, 0, 5, 5))
         assert str(err) == 'Invalid grid detected'
+
+
+def test_filter_with_angle():
+    """Ensure that em.filter will keep an angle variable even without an appropriate standard_name."""
+    eta = np.arange(40)
+    xi = np.arange(20)
+    angle = np.arange(40 * 20).reshape(40, 20)
+    data_dict = {}
+    data_dict['eta'] = xr.DataArray(eta, dims=('eta',))
+    data_dict['xi'] = xr.DataArray(xi, dims=('xi',))
+    data_dict['angle'] = xr.DataArray(angle, dims=('eta', 'xi'))
+    ds = xr.Dataset(data_dict)
+    ds = ds.em.filter([])
+    assert 'angle' in ds.variables

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -184,7 +184,7 @@ def test_sub_grid_assert():
 
 def test_naive_subbox_illegal_grid():
     """Ensure that we raise when the grid is invalid.
-    
+
     An invalid grid can sometimes arise from someone mislabling a variable as a
     coordinate or other copypasta errors.
     """
@@ -193,14 +193,22 @@ def test_naive_subbox_illegal_grid():
     lon = np.linspace(-30, 40, 100)
     _, lat = np.meshgrid(lon, np.linspace(-20, 20, 100))
     data_dict = {}
-    data_dict['eta'] = xr.DataArray(eta, dims=('eta',))
-    data_dict['xi'] = xr.DataArray(xi, dims=('xi',))
-    data_dict['lon'] = xr.DataArray(lon, dims=('lon',), attrs={'standard_name': 'longitude', 'units': 'degrees_east'})
-    data_dict['lat'] = xr.DataArray(lat, dims=('eta', 'xi'), attrs={'standard_name': 'latitude', 'units': 'degrees_north'})
+    data_dict["eta"] = xr.DataArray(eta, dims=("eta",))
+    data_dict["xi"] = xr.DataArray(xi, dims=("xi",))
+    data_dict["lon"] = xr.DataArray(
+        lon,
+        dims=("lon",),
+        attrs={"standard_name": "longitude", "units": "degrees_east"},
+    )
+    data_dict["lat"] = xr.DataArray(
+        lat,
+        dims=("eta", "xi"),
+        attrs={"standard_name": "latitude", "units": "degrees_north"},
+    )
     ds = xr.Dataset(data_dict)
     with pytest.raises(ValueError) as err:
         em.utils.naive_subbox(ds=ds, bbox=(0, 0, 5, 5))
-        assert str(err) == 'Invalid grid detected'
+        assert str(err) == "Invalid grid detected"
 
 
 def test_filter_with_angle():
@@ -209,9 +217,9 @@ def test_filter_with_angle():
     xi = np.arange(20)
     angle = np.arange(40 * 20).reshape(40, 20)
     data_dict = {}
-    data_dict['eta'] = xr.DataArray(eta, dims=('eta',))
-    data_dict['xi'] = xr.DataArray(xi, dims=('xi',))
-    data_dict['angle'] = xr.DataArray(angle, dims=('eta', 'xi'))
+    data_dict["eta"] = xr.DataArray(eta, dims=("eta",))
+    data_dict["xi"] = xr.DataArray(xi, dims=("xi",))
+    data_dict["angle"] = xr.DataArray(angle, dims=("eta", "xi"))
     ds = xr.Dataset(data_dict)
     ds = ds.em.filter([])
-    assert 'angle' in ds.variables
+    assert "angle" in ds.variables


### PR DESCRIPTION
When subsetting unstructured grids, a mask is ultimately needed for processing, but internally to xarray if a mask is used for a selector, it causes any fetching to fetch the entire variable even if a smaller portion would do. This commit enables the client to pass preload=True which will perform a more intelligent selection of the indices (isel), then call ds.load() which will fetch the minimum selection needed for subsetting. This radically improves performance.

## Pull Request Reminders
- [x] Make sure the notebooks in the `docs` directory all run.
- [x] Add tests for the new functionality.
- [x] Add a bullet to `docs/whats_new.rst` describing your new work. If not already present, add a new section at the top of the document stating "[expected new version number] (unreleased)", for example: "v0.7.3 (unreleased)"
