### PR TITLE
preprocessing accounts for more

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1,6 +1,10 @@
 :mod:`What's New`
 -----------------
 
+v1.2.1 (September 22, 2023)
+===========================
+* ROMS preprocessing checks for 3D instead of just 4D data variables now to update their coordinates to work better with cf-xarray. Also coordinates could say "x_rho" and "y_rho" instead of longitudes and latitudes in which case they are changed to say the coordinates
+
 v1.2.0 (September 13, 2023)
 ===========================
 * Improvements to interpolation


### PR DESCRIPTION
ROMS preprocessing checks for 3D instead of just 4D data variables now to update their coordinates to work better with cf-xarray. Also coordinates could say "x_rho" and "y_rho" instead of longitudes and latitudes in which case they are changed to say the coordinates.

## Pull Request Reminders
- [ ] Add tests for the new functionality.
- [x] Add a bullet to `docs/whats_new.rst` describing your new work. If not already present, add a new section at the top of the document stating "[expected new version number] (unreleased)", for example: "v0.7.3 (unreleased)"
